### PR TITLE
Detect changes in underlying file assets

### DIFF
--- a/provider/pkg/runner/fileasset_test.go
+++ b/provider/pkg/runner/fileasset_test.go
@@ -1,10 +1,17 @@
 package runner
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func sha256Hex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
 
 func strPtr(s string) *string { return &s }
 func intPtr(i int) *int       { return &i }
@@ -82,5 +89,127 @@ func TestValidate_MissingMode(t *testing.T) {
 	}
 	if err := asset.Validate(); err == nil {
 		t.Fatal("expected error when Mode is missing")
+	}
+}
+
+func TestGetHash_LocalPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+
+	content := "hello world"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	asset := FileAsset{LocalPath: strPtr(path), Filename: strPtr("test.txt")}
+	got, err := asset.GetHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := sha256Hex(content)
+	if got != want {
+		t.Errorf("GetHash() = %s, want %s", got, want)
+	}
+}
+
+func TestGetHash_Contents(t *testing.T) {
+	content := "inline content"
+	asset := FileAsset{Contents: strPtr(content), Filename: strPtr("inline.txt")}
+
+	got, err := asset.GetHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := sha256Hex(content)
+	if got != want {
+		t.Errorf("GetHash() = %s, want %s", got, want)
+	}
+}
+
+func TestGetHash_NeitherSet(t *testing.T) {
+	asset := FileAsset{Filename: strPtr("empty.txt")}
+	_, err := asset.GetHash()
+	if err == nil {
+		t.Fatal("expected error when neither LocalPath nor Contents is set")
+	}
+}
+
+func TestGetHash_MissingFile(t *testing.T) {
+	asset := FileAsset{LocalPath: strPtr("/nonexistent/path/file.txt"), Filename: strPtr("file.txt")}
+	_, err := asset.GetHash()
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestComputePayloadHashes_MultipleSlices(t *testing.T) {
+	c1 := "content one"
+	c2 := "content two"
+	c3 := "content three"
+
+	slice1 := []FileAsset{
+		{Contents: strPtr(c1), Filename: strPtr("a.txt")},
+		{Contents: strPtr(c2), Filename: strPtr("b.txt")},
+	}
+	slice2 := []FileAsset{
+		{Contents: strPtr(c3), Filename: strPtr("c.txt")},
+	}
+
+	hashes, err := ComputePayloadHashes(slice1, slice2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(hashes) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(hashes))
+	}
+
+	for name, content := range map[string]string{"a.txt": c1, "b.txt": c2, "c.txt": c3} {
+		if hashes[name] != sha256Hex(content) {
+			t.Errorf("hash mismatch for %s", name)
+		}
+	}
+}
+
+func TestComputePayloadHashes_NilFilenameSkipped(t *testing.T) {
+	slice := []FileAsset{
+		{Contents: strPtr("data"), Filename: nil},
+		{Contents: strPtr("data"), Filename: strPtr("keep.txt")},
+	}
+
+	hashes, err := ComputePayloadHashes(slice)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(hashes) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(hashes))
+	}
+	if _, ok := hashes["keep.txt"]; !ok {
+		t.Error("expected keep.txt in hashes")
+	}
+}
+
+func TestComputePayloadHashes_Empty(t *testing.T) {
+	hashes, err := ComputePayloadHashes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hashes) != 0 {
+		t.Fatalf("expected empty map, got %d entries", len(hashes))
+	}
+}
+
+func TestComputePayloadHashes_PropagatesGetHashError(t *testing.T) {
+	slice := []FileAsset{
+		{Contents: strPtr("good"), Filename: strPtr("ok.txt")},
+		{LocalPath: strPtr("/nonexistent/bad.txt"), Filename: strPtr("bad.txt")},
+	}
+
+	_, err := ComputePayloadHashes(slice)
+	if err == nil {
+		t.Fatal("expected error to propagate from failing GetHash")
 	}
 }

--- a/provider/pkg/runner/fileasset_test.go
+++ b/provider/pkg/runner/fileasset_test.go
@@ -1,0 +1,86 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func strPtr(s string) *string { return &s }
+func intPtr(i int) *int       { return &i }
+
+func TestValidate_ValidLocalPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(path, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	asset := FileAsset{
+		LocalPath: strPtr(path),
+		Filename:  strPtr("test.txt"),
+		Mode:      intPtr(0644),
+	}
+	if err := asset.Validate(); err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidate_ValidContents(t *testing.T) {
+	asset := FileAsset{
+		Contents: strPtr("hello"),
+		Filename: strPtr("hello.txt"),
+		Mode:     intPtr(0644),
+	}
+	if err := asset.Validate(); err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidate_NeitherSet(t *testing.T) {
+	asset := FileAsset{
+		Filename: strPtr("empty.txt"),
+		Mode:     intPtr(0644),
+	}
+	if err := asset.Validate(); err == nil {
+		t.Fatal("expected error when neither LocalPath nor Contents is set")
+	}
+}
+
+func TestValidate_BothSet(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(path, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	asset := FileAsset{
+		LocalPath: strPtr(path),
+		Contents:  strPtr("also data"),
+		Filename:  strPtr("test.txt"),
+		Mode:      intPtr(0644),
+	}
+	if err := asset.Validate(); err == nil {
+		t.Fatal("expected error when both LocalPath and Contents are set")
+	}
+}
+
+func TestValidate_MissingFilename(t *testing.T) {
+	asset := FileAsset{
+		Contents: strPtr("data"),
+		Mode:     intPtr(0644),
+	}
+	if err := asset.Validate(); err == nil {
+		t.Fatal("expected error when Filename is missing")
+	}
+}
+
+func TestValidate_MissingMode(t *testing.T) {
+	asset := FileAsset{
+		Contents: strPtr("data"),
+		Filename: strPtr("test.txt"),
+	}
+	if err := asset.Validate(); err == nil {
+		t.Fatal("expected error when Mode is missing")
+	}
+}

--- a/provider/pkg/runner/sshdeployer.go
+++ b/provider/pkg/runner/sshdeployer.go
@@ -6,6 +6,10 @@ import (
 	"maps"
 	"os"
 
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+
 	"github.com/abklabs/pulumi-runner/pkg/ssh"
 	"github.com/abklabs/pulumi-runner/pkg/utils"
 	svmkitRunner "github.com/abklabs/svmkit/pkg/runner"
@@ -32,6 +36,21 @@ type SSHDeployerArgs struct {
 // SSHDeployerState represents the state of an SSHDeployer resource
 type SSHDeployerState struct {
 	SSHDeployerArgs
+	PayloadHashes map[string]string `pulumi:"payloadHashes,optional"`
+}
+
+func (a SSHDeployerArgs) allPayloads() [][]FileAsset {
+	var payloads [][]FileAsset
+
+	payloads = append(payloads, a.Payload)
+
+	for _, def := range []*CommandDefinition{a.Create, a.Update, a.Delete} {
+		if def != nil {
+			payloads = append(payloads, def.Payload)
+		}
+	}
+
+	return payloads
 }
 
 // runDeployerCommand executes a deployment command
@@ -81,6 +100,15 @@ func (SSHDeployer) Create(ctx context.Context, name string, input SSHDeployerArg
 		return "", SSHDeployerState{}, err
 	}
 
+	if !preview {
+		hashes, err := ComputePayloadHashes(input.allPayloads()...)
+		if err != nil {
+			p.GetLogger(ctx).Warning("failed to compute payload hashes: " + err.Error())
+		} else {
+			state.PayloadHashes = hashes
+		}
+	}
+
 	return name, state, nil
 }
 
@@ -101,12 +129,93 @@ func (SSHDeployer) Update(ctx context.Context, name string, state SSHDeployerSta
 		return SSHDeployerState{}, err
 	}
 
+	if !preview {
+		hashes, err := ComputePayloadHashes(newInput.allPayloads()...)
+		if err != nil {
+			p.GetLogger(ctx).Warning("failed to compute payload hashes: " + err.Error())
+		} else {
+			state.PayloadHashes = hashes
+		}
+	}
+
 	return state, nil
 }
 
 func (SSHDeployer) Delete(ctx context.Context, name string, state SSHDeployerState) error {
 	err := runDeployerCommand(ctx, state.Delete, &state, false)
 	return err
+}
+
+func convertDiffKind(k plugin.DiffKind) p.DiffKind {
+	switch k {
+	case plugin.DiffAdd:
+		return p.Add
+	case plugin.DiffAddReplace:
+		return p.AddReplace
+	case plugin.DiffDelete:
+		return p.Delete
+	case plugin.DiffDeleteReplace:
+		return p.DeleteReplace
+	case plugin.DiffUpdate:
+		return p.Update
+	case plugin.DiffUpdateReplace:
+		return p.UpdateReplace
+	default:
+		return p.Update
+	}
+}
+
+func (SSHDeployer) Diff(ctx context.Context, id string, olds SSHDeployerState, news SSHDeployerArgs) (p.DiffResponse, error) {
+	resp := p.DiffResponse{
+		DetailedDiff: make(map[string]p.PropertyDiff),
+	}
+
+	// Structural diff on input properties.
+	oldMap := resource.NewPropertyMap(olds.SSHDeployerArgs)
+	newMap := resource.NewPropertyMap(news)
+
+	if objDiff := oldMap.Diff(newMap); objDiff != nil {
+		for k, v := range plugin.NewDetailedDiffFromObjectDiff(objDiff, true) {
+			resp.DetailedDiff[k] = p.PropertyDiff{
+				Kind:      convertDiffKind(v.Kind),
+				InputDiff: v.InputDiff,
+			}
+		}
+	}
+
+	// Hash-based diff on payload file contents.
+	newHashes, err := ComputePayloadHashes(news.allPayloads()...)
+	if err != nil {
+		p.GetLogger(ctx).Warning("failed to compute payload hashes, assuming changed: " + err.Error())
+		resp.DetailedDiff["payloadHashes"] = p.PropertyDiff{Kind: p.Update, InputDiff: true}
+		resp.HasChanges = true
+		return resp, nil
+	}
+
+	oldHashes := olds.PayloadHashes
+
+	// Nil old hashes means state predates this feature; force an update so
+	// hashes get persisted.
+	if oldHashes == nil {
+		resp.DetailedDiff["payloadHashes"] = p.PropertyDiff{Kind: p.Update, InputDiff: true}
+	} else {
+		for name, newHash := range newHashes {
+			if oldHash, ok := oldHashes[name]; !ok {
+				resp.DetailedDiff["payloadHashes."+name] = p.PropertyDiff{Kind: p.Add, InputDiff: true}
+			} else if oldHash != newHash {
+				resp.DetailedDiff["payloadHashes."+name] = p.PropertyDiff{Kind: p.Update, InputDiff: true}
+			}
+		}
+		for name := range oldHashes {
+			if _, ok := newHashes[name]; !ok {
+				resp.DetailedDiff["payloadHashes."+name] = p.PropertyDiff{Kind: p.Delete, InputDiff: true}
+			}
+		}
+	}
+
+	resp.HasChanges = len(resp.DetailedDiff) > 0
+
+	return resp, nil
 }
 
 type LocalFile struct{}

--- a/provider/pkg/runner/sshdeployer_test.go
+++ b/provider/pkg/runner/sshdeployer_test.go
@@ -1,0 +1,379 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+
+	"github.com/abklabs/pulumi-runner/pkg/ssh"
+)
+
+func floatPtr(f float64) *float64 { return &f }
+
+func minimalArgs() SSHDeployerArgs {
+	var conn ssh.Connection
+	conn.Host = strPtr("localhost")
+	conn.User = strPtr("root")
+	conn.Port = floatPtr(22)
+	conn.DialErrorLimit = intPtr(10)
+	conn.PerDialTimeout = intPtr(15)
+	return SSHDeployerArgs{
+		Connection: conn,
+	}
+}
+
+func TestDiff_NoChanges(t *testing.T) {
+	args := minimalArgs()
+	args.Payload = []FileAsset{
+		{Contents: strPtr("hello"), Filename: strPtr("a.txt")},
+	}
+
+	olds := SSHDeployerState{
+		SSHDeployerArgs: args,
+		PayloadHashes: map[string]string{
+			"a.txt": sha256Hex("hello"),
+		},
+	}
+
+	resp, err := SSHDeployer{}.Diff(context.Background(), "test-id", olds, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.HasChanges {
+		t.Errorf("expected no changes, got DetailedDiff: %v", resp.DetailedDiff)
+	}
+}
+
+func TestDiff_InputPropertyChange(t *testing.T) {
+	oldArgs := minimalArgs()
+	oldArgs.Environment = map[string]string{"KEY": "old"}
+
+	newArgs := minimalArgs()
+	newArgs.Environment = map[string]string{"KEY": "new"}
+
+	olds := SSHDeployerState{
+		SSHDeployerArgs: oldArgs,
+		PayloadHashes:   map[string]string{},
+	}
+
+	resp, err := SSHDeployer{}.Diff(context.Background(), "test-id", olds, newArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.HasChanges {
+		t.Fatal("expected changes from environment update")
+	}
+
+	hasEnvDiff := false
+	for k := range resp.DetailedDiff {
+		if k == "environment" || k == "environment.KEY" {
+			hasEnvDiff = true
+			break
+		}
+	}
+	if !hasEnvDiff {
+		t.Errorf("expected diff entry for environment, got: %v", resp.DetailedDiff)
+	}
+}
+
+func TestDiff_FileContentChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deploy.sh")
+
+	if err := os.WriteFile(path, []byte("v1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldArgs := minimalArgs()
+	oldArgs.Payload = []FileAsset{
+		{LocalPath: strPtr(path), Filename: strPtr("deploy.sh")},
+	}
+
+	newArgs := minimalArgs()
+	newArgs.Payload = []FileAsset{
+		{LocalPath: strPtr(path), Filename: strPtr("deploy.sh")},
+	}
+
+	olds := SSHDeployerState{
+		SSHDeployerArgs: oldArgs,
+		PayloadHashes: map[string]string{
+			"deploy.sh": sha256Hex("v0"),
+		},
+	}
+
+	resp, err := SSHDeployer{}.Diff(context.Background(), "test-id", olds, newArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.HasChanges {
+		t.Fatal("expected changes from file content change")
+	}
+	if _, ok := resp.DetailedDiff["payloadHashes.deploy.sh"]; !ok {
+		t.Error("expected payloadHashes.deploy.sh in DetailedDiff")
+	}
+}
+
+func TestDiff_NilOldHashes(t *testing.T) {
+	args := minimalArgs()
+	args.Payload = []FileAsset{
+		{Contents: strPtr("data"), Filename: strPtr("f.txt")},
+	}
+
+	olds := SSHDeployerState{
+		SSHDeployerArgs: args,
+		PayloadHashes:   nil,
+	}
+
+	resp, err := SSHDeployer{}.Diff(context.Background(), "test-id", olds, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.HasChanges {
+		t.Fatal("expected forced update when old hashes are nil")
+	}
+}
+
+func TestDiff_NewFileAdded(t *testing.T) {
+	args := minimalArgs()
+	args.Payload = []FileAsset{
+		{Contents: strPtr("existing"), Filename: strPtr("old.txt")},
+		{Contents: strPtr("new"), Filename: strPtr("new.txt")},
+	}
+
+	olds := SSHDeployerState{
+		SSHDeployerArgs: minimalArgs(),
+		PayloadHashes: map[string]string{
+			"old.txt": sha256Hex("existing"),
+		},
+	}
+
+	resp, err := SSHDeployer{}.Diff(context.Background(), "test-id", olds, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.HasChanges {
+		t.Fatal("expected changes from new file")
+	}
+
+	diff, ok := resp.DetailedDiff["payloadHashes.new.txt"]
+	if !ok {
+		t.Fatal("expected payloadHashes.new.txt in DetailedDiff")
+	}
+	if diff.Kind != p.Add {
+		t.Errorf("expected Add kind, got %s", diff.Kind)
+	}
+}
+
+func TestDiff_FileRemoved(t *testing.T) {
+	args := minimalArgs()
+
+	olds := SSHDeployerState{
+		SSHDeployerArgs: minimalArgs(),
+		PayloadHashes: map[string]string{
+			"gone.txt": sha256Hex("old data"),
+		},
+	}
+
+	resp, err := SSHDeployer{}.Diff(context.Background(), "test-id", olds, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.HasChanges {
+		t.Fatal("expected changes from removed file")
+	}
+
+	diff, ok := resp.DetailedDiff["payloadHashes.gone.txt"]
+	if !ok {
+		t.Fatal("expected payloadHashes.gone.txt in DetailedDiff")
+	}
+	if diff.Kind != p.Delete {
+		t.Errorf("expected Delete kind, got %s", diff.Kind)
+	}
+}
+
+func TestAllPayloads_CollectsAll(t *testing.T) {
+	args := SSHDeployerArgs{
+		Payload: []FileAsset{{Contents: strPtr("g"), Filename: strPtr("global.txt")}},
+		Create:  &CommandDefinition{Command: "c", Payload: []FileAsset{{Contents: strPtr("c"), Filename: strPtr("create.txt")}}},
+		Update:  &CommandDefinition{Command: "u", Payload: []FileAsset{{Contents: strPtr("u"), Filename: strPtr("update.txt")}}},
+		Delete:  &CommandDefinition{Command: "d", Payload: []FileAsset{{Contents: strPtr("d"), Filename: strPtr("delete.txt")}}},
+	}
+
+	payloads := args.allPayloads()
+	if len(payloads) != 4 {
+		t.Fatalf("expected 4 payload slices, got %d", len(payloads))
+	}
+}
+
+func TestAllPayloads_NilCommandDefinitions(t *testing.T) {
+	args := SSHDeployerArgs{
+		Payload: []FileAsset{{Contents: strPtr("g"), Filename: strPtr("global.txt")}},
+	}
+
+	payloads := args.allPayloads()
+	// Global payload only; nil Create/Update/Delete are skipped.
+	if len(payloads) != 1 {
+		t.Fatalf("expected 1 payload slice, got %d", len(payloads))
+	}
+}
+
+func TestDiff_HashComputationFailure(t *testing.T) {
+	args := minimalArgs()
+	args.Payload = []FileAsset{
+		{LocalPath: strPtr("/nonexistent/missing.sh"), Filename: strPtr("missing.sh")},
+	}
+
+	olds := SSHDeployerState{
+		SSHDeployerArgs: minimalArgs(),
+		PayloadHashes: map[string]string{
+			"missing.sh": sha256Hex("old content"),
+		},
+	}
+
+	resp, err := SSHDeployer{}.Diff(context.Background(), "test-id", olds, args)
+	if err != nil {
+		t.Fatal("expected nil error on hash failure fallback, got:", err)
+	}
+	if !resp.HasChanges {
+		t.Fatal("expected HasChanges when hash computation fails")
+	}
+	diff, ok := resp.DetailedDiff["payloadHashes"]
+	if !ok {
+		t.Fatal("expected payloadHashes key in DetailedDiff")
+	}
+	if diff.Kind != p.Update {
+		t.Errorf("expected Update kind, got %s", diff.Kind)
+	}
+}
+
+func TestDiff_StructuralAndHashChangeCombined(t *testing.T) {
+	oldArgs := minimalArgs()
+	oldArgs.Environment = map[string]string{"KEY": "old"}
+	oldArgs.Payload = []FileAsset{
+		{Contents: strPtr("v1"), Filename: strPtr("app.txt")},
+	}
+
+	newArgs := minimalArgs()
+	newArgs.Environment = map[string]string{"KEY": "new"}
+	newArgs.Payload = []FileAsset{
+		{Contents: strPtr("v2"), Filename: strPtr("app.txt")},
+	}
+
+	olds := SSHDeployerState{
+		SSHDeployerArgs: oldArgs,
+		PayloadHashes: map[string]string{
+			"app.txt": sha256Hex("v1"),
+		},
+	}
+
+	resp, err := SSHDeployer{}.Diff(context.Background(), "test-id", olds, newArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.HasChanges {
+		t.Fatal("expected changes")
+	}
+
+	// Structural diff should detect the environment change.
+	hasStructural := false
+	for k := range resp.DetailedDiff {
+		if k == "environment" || k == "environment.KEY" {
+			hasStructural = true
+			break
+		}
+	}
+	if !hasStructural {
+		t.Errorf("expected structural diff entry for environment, got: %v", resp.DetailedDiff)
+	}
+
+	// Hash diff should detect the payload content change.
+	if _, ok := resp.DetailedDiff["payloadHashes.app.txt"]; !ok {
+		t.Errorf("expected hash diff entry for app.txt, got: %v", resp.DetailedDiff)
+	}
+}
+
+func TestDiff_EmptyNonNilHashesNoPayloads(t *testing.T) {
+	args := minimalArgs()
+
+	olds := SSHDeployerState{
+		SSHDeployerArgs: args,
+		PayloadHashes:   map[string]string{},
+	}
+
+	resp, err := SSHDeployer{}.Diff(context.Background(), "test-id", olds, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.HasChanges {
+		t.Errorf("expected no changes with empty hashes and no payloads, got DetailedDiff: %v", resp.DetailedDiff)
+	}
+}
+
+func TestAllPayloads_PartialCommandDefinitions(t *testing.T) {
+	args := SSHDeployerArgs{
+		Payload: []FileAsset{{Contents: strPtr("g"), Filename: strPtr("global.txt")}},
+		Create:  &CommandDefinition{Command: "c", Payload: []FileAsset{{Contents: strPtr("c"), Filename: strPtr("create.txt")}}},
+		Delete:  &CommandDefinition{Command: "d", Payload: []FileAsset{{Contents: strPtr("d"), Filename: strPtr("delete.txt")}}},
+	}
+
+	payloads := args.allPayloads()
+	if len(payloads) != 3 {
+		t.Fatalf("expected 3 payload slices (global + create + delete), got %d", len(payloads))
+	}
+}
+
+func TestConvertDiffKind(t *testing.T) {
+	cases := []struct {
+		input plugin.DiffKind
+		want  p.DiffKind
+	}{
+		{plugin.DiffAdd, p.Add},
+		{plugin.DiffAddReplace, p.AddReplace},
+		{plugin.DiffDelete, p.Delete},
+		{plugin.DiffDeleteReplace, p.DeleteReplace},
+		{plugin.DiffUpdate, p.Update},
+		{plugin.DiffUpdateReplace, p.UpdateReplace},
+	}
+
+	for _, tc := range cases {
+		got := convertDiffKind(tc.input)
+		if got != tc.want {
+			t.Errorf("convertDiffKind(%d) = %s, want %s", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestConvertDiffKind_UnknownDefault(t *testing.T) {
+	got := convertDiffKind(plugin.DiffKind(99))
+	if got != p.Update {
+		t.Errorf("convertDiffKind(99) = %s, want %s", got, p.Update)
+	}
+}
+
+func TestComputePayloadHashes_DuplicateFilenameLastWriterWins(t *testing.T) {
+	global := []FileAsset{
+		{Contents: strPtr("global version"), Filename: strPtr("deploy.sh")},
+	}
+	cmdPayload := []FileAsset{
+		{Contents: strPtr("command version"), Filename: strPtr("deploy.sh")},
+	}
+
+	hashes, err := ComputePayloadHashes(global, cmdPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(hashes) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(hashes))
+	}
+
+	// The command-level payload is iterated after global, so it wins.
+	want := sha256Hex("command version")
+	if hashes["deploy.sh"] != want {
+		t.Errorf("expected command version hash, got hash of something else")
+	}
+}

--- a/sdk/dotnet/Runner/SSHDeployer.cs
+++ b/sdk/dotnet/Runner/SSHDeployer.cs
@@ -31,6 +31,9 @@ namespace ABKLabs.Runner.Runner
         [Output("payload")]
         public Output<ImmutableArray<Outputs.FileAsset>> Payload { get; private set; } = null!;
 
+        [Output("payloadHashes")]
+        public Output<ImmutableDictionary<string, string>?> PayloadHashes { get; private set; } = null!;
+
         [Output("update")]
         public Output<Outputs.CommandDefinition?> Update { get; private set; } = null!;
 

--- a/sdk/go/runner/sshdeployer.go
+++ b/sdk/go/runner/sshdeployer.go
@@ -16,13 +16,14 @@ import (
 type SSHDeployer struct {
 	pulumi.CustomResourceState
 
-	Config      ConfigPtrOutput            `pulumi:"config"`
-	Connection  ssh.ConnectionOutput       `pulumi:"connection"`
-	Create      CommandDefinitionPtrOutput `pulumi:"create"`
-	Delete      CommandDefinitionPtrOutput `pulumi:"delete"`
-	Environment pulumi.StringMapOutput     `pulumi:"environment"`
-	Payload     FileAssetArrayOutput       `pulumi:"payload"`
-	Update      CommandDefinitionPtrOutput `pulumi:"update"`
+	Config        ConfigPtrOutput            `pulumi:"config"`
+	Connection    ssh.ConnectionOutput       `pulumi:"connection"`
+	Create        CommandDefinitionPtrOutput `pulumi:"create"`
+	Delete        CommandDefinitionPtrOutput `pulumi:"delete"`
+	Environment   pulumi.StringMapOutput     `pulumi:"environment"`
+	Payload       FileAssetArrayOutput       `pulumi:"payload"`
+	PayloadHashes pulumi.StringMapOutput     `pulumi:"payloadHashes"`
+	Update        CommandDefinitionPtrOutput `pulumi:"update"`
 }
 
 // NewSSHDeployer registers a new resource with the given unique name, arguments, and options.
@@ -148,6 +149,10 @@ func (o SSHDeployerOutput) Environment() pulumi.StringMapOutput {
 
 func (o SSHDeployerOutput) Payload() FileAssetArrayOutput {
 	return o.ApplyT(func(v *SSHDeployer) FileAssetArrayOutput { return v.Payload }).(FileAssetArrayOutput)
+}
+
+func (o SSHDeployerOutput) PayloadHashes() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *SSHDeployer) pulumi.StringMapOutput { return v.PayloadHashes }).(pulumi.StringMapOutput)
 }
 
 func (o SSHDeployerOutput) Update() CommandDefinitionPtrOutput {

--- a/sdk/nodejs/runner/sshdeployer.ts
+++ b/sdk/nodejs/runner/sshdeployer.ts
@@ -39,6 +39,7 @@ export class SSHDeployer extends pulumi.CustomResource {
     declare public readonly delete: pulumi.Output<outputs.runner.CommandDefinition | undefined>;
     declare public readonly environment: pulumi.Output<{[key: string]: string} | undefined>;
     declare public readonly payload: pulumi.Output<outputs.runner.FileAsset[] | undefined>;
+    declare public /*out*/ readonly payloadHashes: pulumi.Output<{[key: string]: string} | undefined>;
     declare public readonly update: pulumi.Output<outputs.runner.CommandDefinition | undefined>;
 
     /**
@@ -62,6 +63,7 @@ export class SSHDeployer extends pulumi.CustomResource {
             resourceInputs["environment"] = args?.environment;
             resourceInputs["payload"] = args?.payload;
             resourceInputs["update"] = args?.update;
+            resourceInputs["payloadHashes"] = undefined /*out*/;
         } else {
             resourceInputs["config"] = undefined /*out*/;
             resourceInputs["connection"] = undefined /*out*/;
@@ -69,6 +71,7 @@ export class SSHDeployer extends pulumi.CustomResource {
             resourceInputs["delete"] = undefined /*out*/;
             resourceInputs["environment"] = undefined /*out*/;
             resourceInputs["payload"] = undefined /*out*/;
+            resourceInputs["payloadHashes"] = undefined /*out*/;
             resourceInputs["update"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);

--- a/sdk/python/pulumi_runner/runner/ssh_deployer.py
+++ b/sdk/python/pulumi_runner/runner/ssh_deployer.py
@@ -178,6 +178,7 @@ class SSHDeployer(pulumi.CustomResource):
             __props__.__dict__["environment"] = environment
             __props__.__dict__["payload"] = payload
             __props__.__dict__["update"] = update
+            __props__.__dict__["payload_hashes"] = None
         super(SSHDeployer, __self__).__init__(
             'runner:runner:SSHDeployer',
             resource_name,
@@ -206,6 +207,7 @@ class SSHDeployer(pulumi.CustomResource):
         __props__.__dict__["delete"] = None
         __props__.__dict__["environment"] = None
         __props__.__dict__["payload"] = None
+        __props__.__dict__["payload_hashes"] = None
         __props__.__dict__["update"] = None
         return SSHDeployer(resource_name, opts=opts, __props__=__props__)
 
@@ -238,6 +240,11 @@ class SSHDeployer(pulumi.CustomResource):
     @pulumi.getter
     def payload(self) -> pulumi.Output[Optional[Sequence['outputs.FileAsset']]]:
         return pulumi.get(self, "payload")
+
+    @_builtins.property
+    @pulumi.getter(name="payloadHashes")
+    def payload_hashes(self) -> pulumi.Output[Optional[Mapping[str, _builtins.str]]]:
+        return pulumi.get(self, "payload_hashes")
 
     @_builtins.property
     @pulumi.getter


### PR DESCRIPTION
## Summary

- Unifies content source resolution into a single `FileAsset.openContent()` method, used by `Validate()`, `GetHash()`, and `AddToPayload()`
- Computes SHA-256 hashes of all payload file contents and stores them in resource state
- Implements a custom `Diff()` method on `SSHDeployer` that detects file content changes alongside structural input property changes
- Existing resources without hashes get a one-time forced update to populate them

Resolves OPS-435

## Test plan

- [x] 28 unit tests covering `Validate`, `GetHash`, `ComputePayloadHashes`, `Diff`, `allPayloads`, and `convertDiffKind`
- [x] `go test ./...` passes from the provider directory
- [x] `make build` passes all targets